### PR TITLE
fix decoding of enum to AvroValue, and cover it with tests

### DIFF
--- a/Sources/AvroValue.swift
+++ b/Sources/AvroValue.swift
@@ -383,7 +383,7 @@ public enum AvroValue {
 
         case .AvroEnumSchema(_, let enumValues) :
             if let index = decoder.decodeInt() {
-                if Int(index) > enumValues.count - 1 {
+                if Int(index) < enumValues.count {
                     self = .AvroEnumValue(Int(index), enumValues[Int(index)])
                     return
                 }

--- a/Tests/AvroValueTests.swift
+++ b/Tests/AvroValueTests.swift
@@ -144,6 +144,21 @@ class AvroValueTests: XCTestCase {
         }
     }
 
+    func testEnumValue() {
+        let avroBytes: [UInt8] = [0x12]
+        let jsonSchema = "{ \"type\" : \"enum\", \"name\" : \"ChannelKey\", \"doc\" : \"Enum of valid channel keys.\", \"symbols\" : [ \"CityIphone\", \"CityMobileWeb\", \"GiltAndroid\", \"GiltcityCom\", \"GiltCom\", \"GiltIpad\", \"GiltIpadSafari\", \"GiltIphone\", \"GiltMobileWeb\", \"NoChannel\" ]}"
+
+        let value = AvroValue(jsonSchema: jsonSchema, withBytes: avroBytes)
+
+        switch value {
+        case .AvroEnumValue(let index, let string):
+            XCTAssertEqual(index, 9)
+            XCTAssertEqual(string, "NoChannel")
+        case _:
+            XCTAssert(false, "Invalid avro value")
+        }
+    }
+
     func testUnionValue() {
         let avroBytes: [UInt8] = [0x02, 0x02, 0x61]
         let jsonSchema = "{\"type\" : [\"null\",\"string\"] }"


### PR DESCRIPTION
Found nasty bug. Decoding don't work actually, cause index is out of bounds and if record contain at least one enum it will be decoded as AvroInvalidValue